### PR TITLE
Send all failure messages in a single email

### DIFF
--- a/src/ecdcpipeline/FailureNotifier.groovy
+++ b/src/ecdcpipeline/FailureNotifier.groovy
@@ -20,7 +20,7 @@ class FailureNotifier {
   def send(script, String msg) {
     if (notificationChannels & EMAIL) {
       def toEmails = [[$class: 'DevelopersRecipientProvider']]
-      script.emailext body: '${DEFAULT_CONTENT}\n\"' + msg + '\"\n\nCheck console output at $BUILD_URL to view the results.',
+      script.emailext body: '${DEFAULT_CONTENT}\n' + msg + '\n\nCheck console output at $BUILD_URL to view the results.',
         recipientProviders: toEmails,
         subject: '${DEFAULT_SUBJECT}'
     }

--- a/src/ecdcpipeline/PipelineBuilder.groovy
+++ b/src/ecdcpipeline/PipelineBuilder.groovy
@@ -47,8 +47,8 @@ class PipelineBuilder implements Serializable {
   }
   
   def handleFailureMessages() {
-    String failureMessage = "The following failures were encountered when building:\n"
-    this.failure_messages.eachWithIndex{message, index -> failureMessage += "${index}: ${message}\n"}
+    String failureMessage = "The following failures were encountered:\n"
+    this.failure_messages.eachWithIndex{message, index -> failureMessage += "${index+1}: ${message}\n"}
     failureNotifier.send(script, failureMessage)
   }
 

--- a/src/ecdcpipeline/PipelineBuilder.groovy
+++ b/src/ecdcpipeline/PipelineBuilder.groovy
@@ -37,6 +37,10 @@ class PipelineBuilder implements Serializable {
 
     this.failureNotifier = new FailureNotifier(script.env.JOB_NAME)
   }
+  
+  void finalize() {
+    println "Destructor!"
+  }
 
   def activateEmailFailureNotifications() {
     failureNotifier.activateNotificationChannel(FailureNotifier.EMAIL)

--- a/src/ecdcpipeline/PipelineBuilder.groovy
+++ b/src/ecdcpipeline/PipelineBuilder.groovy
@@ -39,6 +39,7 @@ class PipelineBuilder implements Serializable {
   }
   
   void finalize() {
+    this.failure_messages.eachWithIndex{message, index -> println "${index}: ${message}"}
     println "Destructor!"
   }
 

--- a/src/ecdcpipeline/PipelineBuilder.groovy
+++ b/src/ecdcpipeline/PipelineBuilder.groovy
@@ -10,6 +10,8 @@ class PipelineBuilder implements Serializable {
   String branch
   String buildNumber
   String baseContainerName
+  
+  def failure_messages
 
   private def script
   private def containerBuildNodes
@@ -29,6 +31,7 @@ class PipelineBuilder implements Serializable {
     def (org, project, branch) = "${script.env.JOB_NAME}".tokenize('/')
     this.project = project
     this.branch = branch
+    this.failure_messages = Collections.synchronizedList([])
     this.buildNumber = script.env.BUILD_NUMBER
     this.baseContainerName = "${project}-${branch}-${buildNumber}"
 
@@ -57,6 +60,7 @@ class PipelineBuilder implements Serializable {
       script.stage(name, stageCommands)
     } catch(e) {
       def msg = "pipeline failed in stage ${name}"
+      this.failure_messages.add(msg)
       failureNotifier.send(script, msg)
       throw e
     }


### PR DESCRIPTION
The changes require that you call `parallel` in your _Jenkinsfile_ as follows:
```
try {
  parallel builders
  } catch (e) {
    pipeline_builder.handleFailureMessages()
    throw e
}
```