### PR TITLE
Update build node image versions

### DIFF
--- a/src/ecdcpipeline/DefaultContainerBuildNodeImages.groovy
+++ b/src/ecdcpipeline/DefaultContainerBuildNodeImages.groovy
@@ -8,7 +8,7 @@ class DefaultContainerBuildNodeImages {
       'shell': '/usr/bin/scl enable devtoolset-6 -- /bin/bash -e -x'
     ],
     'centos7-gcc8': [
-      'image': 'screamingudder/centos7-build-node:5.0.5',
+      'image': 'screamingudder/centos7-build-node:5.0.6',
       'shell': '/usr/bin/scl enable devtoolset-8 -- /bin/bash -e -x'
     ],
     'debian9': [
@@ -16,7 +16,7 @@ class DefaultContainerBuildNodeImages {
       'shell': 'bash -e -x'
     ],
     'debian10': [
-      'image': 'screamingudder/debian10-build-node:1.0.3',
+      'image': 'screamingudder/debian10-build-node:1.0.4',
       'shell': 'bash -e -x'
     ],
     'ubuntu1804': [

--- a/src/ecdcpipeline/DefaultContainerBuildNodeImages.groovy
+++ b/src/ecdcpipeline/DefaultContainerBuildNodeImages.groovy
@@ -24,11 +24,11 @@ class DefaultContainerBuildNodeImages {
       'shell': 'bash -e -x'
     ],
     'ubuntu1804-gcc8': [
-      'image': 'screamingudder/ubuntu18.04-build-node:3.0.2',
+      'image': 'screamingudder/ubuntu18.04-build-node:3.0.3',
       'shell': 'bash -e -x'
     ],
     'alpine': [
-      'image': 'screamingudder/alpine-build-node:2.0.0',
+      'image': 'screamingudder/alpine-build-node:2.0.1',
       'shell': 'bash -e -x'
     ]
   ]

--- a/src/ecdcpipeline/DefaultContainerBuildNodeImages.groovy
+++ b/src/ecdcpipeline/DefaultContainerBuildNodeImages.groovy
@@ -24,7 +24,7 @@ class DefaultContainerBuildNodeImages {
       'shell': 'bash -e -x'
     ],
     'ubuntu1804-gcc8': [
-      'image': 'screamingudder/ubuntu18.04-build-node:3.0.3',
+      'image': 'screamingudder/ubuntu18.04-build-node:3.0.4',
       'shell': 'bash -e -x'
     ],
     'alpine': [


### PR DESCRIPTION
Make the default `gcov` version match the default compiler version on Ubuntu.
Remove superfluous packages from Alpine image.
Add ninja to all (gcc8+) images.