### PR TITLE
Update DefaultContainerBuildNodeImages.groovy

### DIFF
--- a/src/ecdcpipeline/DefaultContainerBuildNodeImages.groovy
+++ b/src/ecdcpipeline/DefaultContainerBuildNodeImages.groovy
@@ -8,7 +8,7 @@ class DefaultContainerBuildNodeImages {
       'shell': '/usr/bin/scl enable devtoolset-6 -- /bin/bash -e -x'
     ],
     'centos7-gcc8': [
-      'image': 'screamingudder/centos7-build-node:5.0.6',
+      'image': 'screamingudder/centos7-build-node:5.0.7',
       'shell': '/usr/bin/scl enable devtoolset-8 -- /bin/bash -e -x'
     ],
     'debian9': [


### PR DESCRIPTION
Update CentOS image: Alias `ninja-build` as `ninja` on CentOS so that command is the same as on our other Linux distros.