### PR TITLE
Dm 2060 keep build node images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ node('docker') {
     stage('Run tests') {
       sh """
         for filepath in \$(ls test/ecdcpipeline/*Test.groovy); do
-          /opt/dm_group/groovy/current/bin/groovy --classpath src:test $filepath
+          /opt/dm_group/groovy/current/bin/groovy --classpath src:test \$filepath
         done
       """
     }  // stage

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,14 +11,6 @@ node('docker') {
       scmVars = checkout scm
     }
 
-    stage('Run tests') {
-      sh """
-        for filepath in \$(ls test/ecdcpipeline/*Test.groovy); do
-          /opt/dm_group/groovy/current/bin/groovy --classpath src:test \$filepath
-        done
-      """
-    }  // stage
-
     stage('Create documentation') {
       sh """
         /opt/dm_group/groovy/current/bin/groovydoc -sourcepath src -d ../docs 'ecdcpipeline' '*.groovy'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,6 +11,14 @@ node('docker') {
       scmVars = checkout scm
     }
 
+    stage('Run tests') {
+      sh """
+        for filepath in $(ls test/ecdcpipeline/*Test.groovy); do
+          /opt/dm_group/groovy/current/bin/groovy --classpath src:test $filepath
+        done
+      """
+    }  // stage
+
     stage('Create documentation') {
       sh """
         /opt/dm_group/groovy/current/bin/groovydoc -sourcepath src -d ../docs 'ecdcpipeline' '*.groovy'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ node('docker') {
 
     stage('Run tests') {
       sh """
-        for filepath in $(ls test/ecdcpipeline/*Test.groovy); do
+        for filepath in \$(ls test/ecdcpipeline/*Test.groovy); do
           /opt/dm_group/groovy/current/bin/groovy --classpath src:test $filepath
         done
       """

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
 for filepath in $(ls test/ecdcpipeline/*Test.groovy); do
+  echo "Running tests in ${filepath}"
   groovy --classpath src:test $filepath
 done

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+for filepath in $(ls test/ecdcpipeline/*Test.groovy); do
+  groovy --classpath src:test $filepath
+done

--- a/src/ecdcpipeline/ContainerBuildNode.groovy
+++ b/src/ecdcpipeline/ContainerBuildNode.groovy
@@ -18,8 +18,6 @@ class ContainerBuildNode implements Serializable  {
   String shell
 
   /**
-   * <p></p>
-   *
    * This is the recommended approach for getting container build nodes for
    * regular builds.
    *

--- a/src/ecdcpipeline/DockerOutputParser.groovy
+++ b/src/ecdcpipeline/DockerOutputParser.groovy
@@ -7,8 +7,8 @@ class DockerOutputParser implements Serializable {
 
   static final IMAGES_FORMAT = "'{{.Repository}}:{{.Tag}}'"
 
-  def parseImages(output) {
-    def images = output.tokenize("\n")
+  def parseImages(imagesStr) {
+    def images = imagesStr.tokenize("\n")
     return images
   }
 

--- a/src/ecdcpipeline/DockerOutputParser.groovy
+++ b/src/ecdcpipeline/DockerOutputParser.groovy
@@ -1,0 +1,15 @@
+package ecdcpipeline
+
+/**
+ * Docker command output parser.
+ */
+class DockerOutputParser implements Serializable {
+
+  static final IMAGES_FORMAT = "'{{.Repository}}:{{.Tag}}'"
+
+  def parseImages(output) {
+    def images = output.tokenize("\n")
+    return images
+  }
+
+}

--- a/src/ecdcpipeline/DockerWrapper.groovy
+++ b/src/ecdcpipeline/DockerWrapper.groovy
@@ -29,7 +29,7 @@ class DockerWrapper implements Serializable {
   def getImages() {
     def formatStr = this.dockerOutputParser.IMAGES_FORMAT
     def result = this.script.sh(
-      script: "pwd && docker images --format ${formatStr}",
+      script: "pwd && ls",
       returnStdout: true
     ).trim()
     println(result)

--- a/src/ecdcpipeline/DockerWrapper.groovy
+++ b/src/ecdcpipeline/DockerWrapper.groovy
@@ -29,7 +29,7 @@ class DockerWrapper implements Serializable {
   def getImages() {
     def formatStr = dockerOutputParser.IMAGES_FORMAT
     def result = steps.sh(
-      script: "docker images --format ${formatStr} | cat",
+      script: """docker images --format ${formatStr}""",
       returnStdout: true
     )
 

--- a/src/ecdcpipeline/DockerWrapper.groovy
+++ b/src/ecdcpipeline/DockerWrapper.groovy
@@ -7,7 +7,6 @@ import ecdcpipeline.DockerOutputParser
  */
 class DockerWrapper implements Serializable {
 
-  private def script
   private def dockerOutputParser
 
   /**
@@ -16,8 +15,7 @@ class DockerWrapper implements Serializable {
    * @param script reference to the current pipeline script ({@code this} in a
    *   Jenkinsfile)
    */
-  DockerWrapper(script) {
-    this.script = script
+  DockerWrapper() {
     this.dockerOutputParser = new DockerOutputParser()
   }
 
@@ -28,10 +26,7 @@ class DockerWrapper implements Serializable {
    */
   def getImages() {
     def formatStr = this.dockerOutputParser.IMAGES_FORMAT
-    def result = this.script.sh(
-      script: "pwd && ls",
-      returnStdout: true
-    ).trim()
+    def result = "docker images --format ${formatStr}".execute.text.trim()
     println(result)
     def images = this.dockerOutputParser.parseImages(result)
 

--- a/src/ecdcpipeline/DockerWrapper.groovy
+++ b/src/ecdcpipeline/DockerWrapper.groovy
@@ -43,7 +43,8 @@ class DockerWrapper implements Serializable {
    * @param imageNamesToRemove list of image names to remove
    */
   def removeImages(imageNamesToRemove) {
-    // this.script.sh("docker rmi ${' '.join(imageNamesToRemove)}")
-    println("docker rmi ${' '.join(imageNamesToRemove)}")
+    def imageNamesStr = imageNamesToRemove.join(" ")
+    // this.script.sh("docker rmi ${imageNamesStr}")
+    println("docker rmi ${imageNamesStr}")
   }
 }

--- a/src/ecdcpipeline/DockerWrapper.groovy
+++ b/src/ecdcpipeline/DockerWrapper.groovy
@@ -46,6 +46,6 @@ class DockerWrapper implements Serializable {
   def removeImages(imageNamesToRemove) {
     def imageNamesStr = imageNamesToRemove.join(" ")
     // this.script.sh("docker rmi ${imageNamesStr}")
-    echo "docker rmi ${imageNamesStr}"
+    this.script.echo "docker rmi ${imageNamesStr}"
   }
 }

--- a/src/ecdcpipeline/DockerWrapper.groovy
+++ b/src/ecdcpipeline/DockerWrapper.groovy
@@ -7,17 +7,17 @@ import ecdcpipeline.DockerOutputParser
  */
 class DockerWrapper implements Serializable {
 
-  private def steps
+  private def script
   private def dockerOutputParser
 
   /**
    * <p></p>
    *
-   * @param steps reference to the current pipeline script ({@code this} in a
+   * @param script reference to the current pipeline script ({@code this} in a
    *   Jenkinsfile)
    */
-  DockerWrapper(steps) {
-    this.steps = steps
+  DockerWrapper(script) {
+    this.script = script
     this.dockerOutputParser = new DockerOutputParser()
   }
 
@@ -27,17 +27,13 @@ class DockerWrapper implements Serializable {
    * @returns List of image names
    */
   def getImages() {
-    def formatStr = dockerOutputParser.IMAGES_FORMAT
-    def result = steps.sh(
-      script: """docker images --format ${formatStr}""",
+    def formatStr = this.dockerOutputParser.IMAGES_FORMAT
+    def result = this.script.sh(
+      script: "docker images --format ${formatStr}",
       returnStdout: true
-    )
-
-    println("Testing result:")
-    println(result.size())
-    def images = dockerOutputParser.parseImages(result)
-
-    println(steps.sh(script: "pwd", returnStdout: true))
+    ).trim()
+    this.script.echo "${result}"
+    def images = this.dockerOutputParser.parseImages(result)
 
     return images
   }

--- a/src/ecdcpipeline/DockerWrapper.groovy
+++ b/src/ecdcpipeline/DockerWrapper.groovy
@@ -7,7 +7,7 @@ import ecdcpipeline.DockerOutputParser
  */
 class DockerWrapper implements Serializable {
 
-  private def script
+  private def steps
   private def dockerOutputParser
 
   /**

--- a/src/ecdcpipeline/DockerWrapper.groovy
+++ b/src/ecdcpipeline/DockerWrapper.groovy
@@ -23,7 +23,7 @@ class DockerWrapper implements Serializable {
    */
   def getImages() {
     def formatStr = this.dockerOutputParser.IMAGES_FORMAT
-    def result = "docker images --format ${formatStr}".execute().text.trim()
+    def result = "/bin/docker images --format ${formatStr}".execute().text.trim()
     println(result)
     def images = this.dockerOutputParser.parseImages(result)
 

--- a/src/ecdcpipeline/DockerWrapper.groovy
+++ b/src/ecdcpipeline/DockerWrapper.groovy
@@ -32,9 +32,7 @@ class DockerWrapper implements Serializable {
       script: "docker images --format ${formatStr}",
       returnStdout: true
     ).trim()
-    this.script.echo "${result}"
     def images = this.dockerOutputParser.parseImages(result)
-    this.script.echo "${images}"
 
     return images
   }
@@ -46,7 +44,6 @@ class DockerWrapper implements Serializable {
    */
   def removeImages(imageNamesToRemove) {
     def imageNamesStr = imageNamesToRemove.join(" ")
-    // this.script.sh("docker rmi ${imageNamesStr}")
-    this.script.echo "docker rmi ${imageNamesStr}"
+    this.script.sh("docker rmi ${imageNamesStr}")
   }
 }

--- a/src/ecdcpipeline/DockerWrapper.groovy
+++ b/src/ecdcpipeline/DockerWrapper.groovy
@@ -31,7 +31,7 @@ class DockerWrapper implements Serializable {
     def result = this.script.sh(
       script: "docker images --format ${formatStr}",
       returnStdout: true
-    ).trim()
+    )
     println(result)
     def images = this.dockerOutputParser.parseImages(result)
 

--- a/src/ecdcpipeline/DockerWrapper.groovy
+++ b/src/ecdcpipeline/DockerWrapper.groovy
@@ -29,10 +29,10 @@ class DockerWrapper implements Serializable {
   def getImages() {
     def formatStr = dockerOutputParser.IMAGES_FORMAT
     def result = script.sh(
-      script: "docker images --format ${formatStr}",
+      script: "docker images --format ${formatStr} > /tmp/command.output",
       returnStdout: true
     )
-    script.sh("env")
+    script.sh("cat /tmp/command.output")
     println("Testing result:")
     println(result.size())
     def images = dockerOutputParser.parseImages(result)

--- a/src/ecdcpipeline/DockerWrapper.groovy
+++ b/src/ecdcpipeline/DockerWrapper.groovy
@@ -32,6 +32,7 @@ class DockerWrapper implements Serializable {
       script: "docker images --format ${formatStr}",
       returnStdout: true
     )
+    println("Testing result:")
     println(result.size())
     def images = dockerOutputParser.parseImages(result)
 

--- a/src/ecdcpipeline/DockerWrapper.groovy
+++ b/src/ecdcpipeline/DockerWrapper.groovy
@@ -43,6 +43,7 @@ class DockerWrapper implements Serializable {
    * @param imageNamesToRemove list of image names to remove
    */
   def removeImages(imageNamesToRemove) {
-    this.script.sh("docker rmi ${' '.join(imageNamesToRemove)}")
+    // this.script.sh("docker rmi ${' '.join(imageNamesToRemove)}")
+    println("docker rmi ${' '.join(imageNamesToRemove)}")
   }
 }

--- a/src/ecdcpipeline/DockerWrapper.groovy
+++ b/src/ecdcpipeline/DockerWrapper.groovy
@@ -46,6 +46,6 @@ class DockerWrapper implements Serializable {
   def removeImages(imageNamesToRemove) {
     def imageNamesStr = imageNamesToRemove.join(" ")
     // this.script.sh("docker rmi ${imageNamesStr}")
-    println("docker rmi ${imageNamesStr}")
+    echo "docker rmi ${imageNamesStr}"
   }
 }

--- a/src/ecdcpipeline/DockerWrapper.groovy
+++ b/src/ecdcpipeline/DockerWrapper.groovy
@@ -29,7 +29,7 @@ class DockerWrapper implements Serializable {
   def getImages() {
     def formatStr = this.dockerOutputParser.IMAGES_FORMAT
     def output = this.script.sh(
-      script: "docker images --format ${formatStr}",
+      script: "pwd && docker images --format ${formatStr}",
       returnStdout: true
     ).trim()
     println(output)

--- a/src/ecdcpipeline/DockerWrapper.groovy
+++ b/src/ecdcpipeline/DockerWrapper.groovy
@@ -44,8 +44,6 @@ class DockerWrapper implements Serializable {
    */
   def removeImages(imageNamesToRemove) {
     def imageNamesStr = imageNamesToRemove.join(" ")
-    // this.script.sh("docker rmi ${imageNamesStr}")
-    this.script.echo "To remove: ${imageNamesToRemove}"
-    this.script.echo "String: ${imageNamesStr}"
+    this.script.sh("docker rmi ${imageNamesStr}")
   }
 }

--- a/src/ecdcpipeline/DockerWrapper.groovy
+++ b/src/ecdcpipeline/DockerWrapper.groovy
@@ -45,6 +45,7 @@ class DockerWrapper implements Serializable {
   def removeImages(imageNamesToRemove) {
     def imageNamesStr = imageNamesToRemove.join(" ")
     // this.script.sh("docker rmi ${imageNamesStr}")
-    this.script.echo "docker rmi ${imageNamesStr}"
+    this.script.echo "To remove: ${imageNamesToRemove}"
+    this.script.echo "String: ${imageNamesStr}"
   }
 }

--- a/src/ecdcpipeline/DockerWrapper.groovy
+++ b/src/ecdcpipeline/DockerWrapper.groovy
@@ -13,11 +13,11 @@ class DockerWrapper implements Serializable {
   /**
    * <p></p>
    *
-   * @param script reference to the current pipeline script ({@code this} in a
+   * @param steps reference to the current pipeline script ({@code this} in a
    *   Jenkinsfile)
    */
-  DockerWrapper(script) {
-    this.script = script
+  DockerWrapper(steps) {
+    this.steps = steps
     this.dockerOutputParser = new DockerOutputParser()
   }
 
@@ -28,7 +28,7 @@ class DockerWrapper implements Serializable {
    */
   def getImages() {
     def formatStr = dockerOutputParser.IMAGES_FORMAT
-    def result = script.sh(
+    def result = steps.sh(
       script: "docker images --format ${formatStr} | cat",
       returnStdout: true
     )
@@ -37,7 +37,7 @@ class DockerWrapper implements Serializable {
     println(result.size())
     def images = dockerOutputParser.parseImages(result)
 
-    println(script.sh(script: "pwd", returnStdout: true))
+    println(steps.sh(script: "pwd", returnStdout: true))
 
     return images
   }

--- a/src/ecdcpipeline/DockerWrapper.groovy
+++ b/src/ecdcpipeline/DockerWrapper.groovy
@@ -28,7 +28,7 @@ class DockerWrapper implements Serializable {
    */
   def getImages() {
     def formatStr = this.dockerOutputParser.IMAGES_FORMAT
-    output = this.script.sh(
+    def output = this.script.sh(
       script: "docker images --format ${formatStr}",
       returnStdout: true
     ).trim()

--- a/src/ecdcpipeline/DockerWrapper.groovy
+++ b/src/ecdcpipeline/DockerWrapper.groovy
@@ -35,6 +35,8 @@ class DockerWrapper implements Serializable {
     println(result.size())
     def images = this.dockerOutputParser.parseImages(result)
 
+    println(this.script.sh(script: "pwd", returnStdout: true))
+
     return images
   }
 

--- a/src/ecdcpipeline/DockerWrapper.groovy
+++ b/src/ecdcpipeline/DockerWrapper.groovy
@@ -44,6 +44,7 @@ class DockerWrapper implements Serializable {
    */
   def removeImages(imageNamesToRemove) {
     def imageNamesStr = imageNamesToRemove.join(" ")
-    this.script.sh("docker rmi ${imageNamesStr}")
+    // this.script.sh("docker rmi ${imageNamesStr}")
+    this.script.echo "docker rmi ${imageNamesStr}"
   }
 }

--- a/src/ecdcpipeline/DockerWrapper.groovy
+++ b/src/ecdcpipeline/DockerWrapper.groovy
@@ -7,12 +7,17 @@ import ecdcpipeline.DockerOutputParser
  */
 class DockerWrapper implements Serializable {
 
+  private def script
   private def dockerOutputParser
 
   /**
    * <p></p>
+   *
+   * @param script reference to the current pipeline script ({@code this} in a
+   *   Jenkinsfile)
    */
-  DockerWrapper() {
+  DockerWrapper(script) {
+    this.script = script
     this.dockerOutputParser = new DockerOutputParser()
   }
 
@@ -23,7 +28,10 @@ class DockerWrapper implements Serializable {
    */
   def getImages() {
     def formatStr = this.dockerOutputParser.IMAGES_FORMAT
-    def result = "/bin/docker images --format ${formatStr}".execute().text.trim()
+    def result = this.script.sh(
+      script: "docker images --format ${formatStr}",
+      returnStdout: true
+    ).trim()
     println(result)
     def images = this.dockerOutputParser.parseImages(result)
 

--- a/src/ecdcpipeline/DockerWrapper.groovy
+++ b/src/ecdcpipeline/DockerWrapper.groovy
@@ -34,6 +34,7 @@ class DockerWrapper implements Serializable {
     ).trim()
     this.script.echo "${result}"
     def images = this.dockerOutputParser.parseImages(result)
+    this.script.echo "${images}"
 
     return images
   }

--- a/src/ecdcpipeline/DockerWrapper.groovy
+++ b/src/ecdcpipeline/DockerWrapper.groovy
@@ -28,12 +28,12 @@ class DockerWrapper implements Serializable {
    */
   def getImages() {
     def formatStr = this.dockerOutputParser.IMAGES_FORMAT
-    def output = this.script.sh(
+    def result = this.script.sh(
       script: "pwd && docker images --format ${formatStr}",
       returnStdout: true
     ).trim()
-    println(output)
-    def images = this.dockerOutputParser.parseImages(output)
+    println(result)
+    def images = this.dockerOutputParser.parseImages(result)
 
     return images
   }

--- a/src/ecdcpipeline/DockerWrapper.groovy
+++ b/src/ecdcpipeline/DockerWrapper.groovy
@@ -32,7 +32,7 @@ class DockerWrapper implements Serializable {
       script: "docker images --format ${formatStr}",
       returnStdout: true
     )
-    println(result)
+    println(result.size())
     def images = this.dockerOutputParser.parseImages(result)
 
     return images

--- a/src/ecdcpipeline/DockerWrapper.groovy
+++ b/src/ecdcpipeline/DockerWrapper.groovy
@@ -11,8 +11,6 @@ class DockerWrapper implements Serializable {
   private def dockerOutputParser
 
   /**
-   * <p></p>
-   *
    * @param script reference to the current pipeline script ({@code this} in a
    *   Jenkinsfile)
    */

--- a/src/ecdcpipeline/DockerWrapper.groovy
+++ b/src/ecdcpipeline/DockerWrapper.groovy
@@ -29,10 +29,10 @@ class DockerWrapper implements Serializable {
   def getImages() {
     def formatStr = dockerOutputParser.IMAGES_FORMAT
     def result = script.sh(
-      script: "docker images --format ${formatStr} > /tmp/command.output",
+      script: "docker images --format ${formatStr} | cat",
       returnStdout: true
     )
-    script.sh("cat /tmp/command.output")
+
     println("Testing result:")
     println(result.size())
     def images = dockerOutputParser.parseImages(result)

--- a/src/ecdcpipeline/DockerWrapper.groovy
+++ b/src/ecdcpipeline/DockerWrapper.groovy
@@ -27,15 +27,15 @@ class DockerWrapper implements Serializable {
    * @returns List of image names
    */
   def getImages() {
-    def formatStr = this.dockerOutputParser.IMAGES_FORMAT
-    def result = this.script.sh(
+    def formatStr = dockerOutputParser.IMAGES_FORMAT
+    def result = script.sh(
       script: "docker images --format ${formatStr}",
       returnStdout: true
     )
     println(result.size())
-    def images = this.dockerOutputParser.parseImages(result)
+    def images = dockerOutputParser.parseImages(result)
 
-    println(this.script.sh(script: "pwd", returnStdout: true))
+    println(script.sh(script: "pwd", returnStdout: true))
 
     return images
   }

--- a/src/ecdcpipeline/DockerWrapper.groovy
+++ b/src/ecdcpipeline/DockerWrapper.groovy
@@ -32,6 +32,7 @@ class DockerWrapper implements Serializable {
       script: "docker images --format ${formatStr}",
       returnStdout: true
     )
+    script.sh("env")
     println("Testing result:")
     println(result.size())
     def images = dockerOutputParser.parseImages(result)

--- a/src/ecdcpipeline/DockerWrapper.groovy
+++ b/src/ecdcpipeline/DockerWrapper.groovy
@@ -11,9 +11,6 @@ class DockerWrapper implements Serializable {
 
   /**
    * <p></p>
-   *
-   * @param script reference to the current pipeline script ({@code this} in a
-   *   Jenkinsfile)
    */
   DockerWrapper() {
     this.dockerOutputParser = new DockerOutputParser()

--- a/src/ecdcpipeline/DockerWrapper.groovy
+++ b/src/ecdcpipeline/DockerWrapper.groovy
@@ -1,0 +1,48 @@
+package ecdcpipeline
+
+import ecdcpipeline.DockerOutputParser
+
+/**
+ * Wrapper for Docker commands.
+ */
+class DockerWrapper implements Serializable {
+
+  private def script
+  private def dockerOutputParser
+
+  /**
+   * <p></p>
+   *
+   * @param script reference to the current pipeline script ({@code this} in a
+   *   Jenkinsfile)
+   */
+  DockerWrapper(script) {
+    this.script = script
+    this.dockerOutputParser = new DockerOutputParser()
+  }
+
+  /**
+   * Get locally available images.
+   *
+   * @returns List of image names
+   */
+  def getImages() {
+    def formatStr = this.dockerOutputParser.IMAGES_FORMAT
+    output = this.script.sh(
+      script: "docker images --format ${formatStr}",
+      returnStdout: true
+    ).trim()
+    def images = this.dockerOutputParser.parseImages(output)
+
+    return images
+  }
+
+  /**
+   * Remove images.
+   *
+   * @param imageNamesToRemove list of image names to remove
+   */
+  def removeImages(imageNamesToRemove) {
+    this.script.sh("docker rmi ${' '.join(imageNamesToRemove)}")
+  }
+}

--- a/src/ecdcpipeline/DockerWrapper.groovy
+++ b/src/ecdcpipeline/DockerWrapper.groovy
@@ -23,7 +23,7 @@ class DockerWrapper implements Serializable {
    */
   def getImages() {
     def formatStr = this.dockerOutputParser.IMAGES_FORMAT
-    def result = "docker images --format ${formatStr}".execute.text.trim()
+    def result = "docker images --format ${formatStr}".execute().text.trim()
     println(result)
     def images = this.dockerOutputParser.parseImages(result)
 

--- a/src/ecdcpipeline/DockerWrapper.groovy
+++ b/src/ecdcpipeline/DockerWrapper.groovy
@@ -32,6 +32,7 @@ class DockerWrapper implements Serializable {
       script: "docker images --format ${formatStr}",
       returnStdout: true
     ).trim()
+    println(output)
     def images = this.dockerOutputParser.parseImages(output)
 
     return images

--- a/src/ecdcpipeline/ImageRemovalFilter.groovy
+++ b/src/ecdcpipeline/ImageRemovalFilter.groovy
@@ -1,0 +1,33 @@
+package ecdcpipeline
+
+/**
+ * Filter for selecting images to be removed.
+ */
+class ImageRemovalFilter implements Serializable {
+
+  /**
+   * List of image names to be kept.
+   */
+  private def imageNamesToKeep
+
+  /**
+   * <p></p>
+   *
+   * @param imageNamesToKeep list of image names to be kept
+   */
+  ImageRemovalFilter(imageNamesToKeep) {
+    this.imageNamesToKeep = imageNamesToKeep
+  }
+
+  /**
+   * Get a list of filtered image names to remove.
+   *
+   * @param imageNames list of image names
+   *
+   * @returns List of image names to remove
+   */
+  def getFilteredIDsFromImages(imageNames) {
+    return imageNames - imageNamesToKeep
+  }
+
+}

--- a/src/ecdcpipeline/ImageRemovalFilter.groovy
+++ b/src/ecdcpipeline/ImageRemovalFilter.groovy
@@ -11,8 +11,6 @@ class ImageRemovalFilter implements Serializable {
   private def imageNamesToKeep
 
   /**
-   * <p></p>
-   *
    * @param imageNamesToKeep list of image names to be kept
    */
   ImageRemovalFilter(imageNamesToKeep) {

--- a/src/ecdcpipeline/ImageRemovalFilter.groovy
+++ b/src/ecdcpipeline/ImageRemovalFilter.groovy
@@ -26,7 +26,7 @@ class ImageRemovalFilter implements Serializable {
    *
    * @returns List of image names to remove
    */
-  def getFilteredIDsFromImages(imageNames) {
+  def getFilteredImageNames(imageNames) {
     return imageNames - imageNamesToKeep
   }
 

--- a/src/ecdcpipeline/ImageRemovalFilter.groovy
+++ b/src/ecdcpipeline/ImageRemovalFilter.groovy
@@ -24,7 +24,7 @@ class ImageRemovalFilter implements Serializable {
    *
    * @param imageNames list of image names
    *
-   * @returns List of image names to remove
+   * @return List of image names to remove
    */
   def getFilteredImageNames(imageNames) {
     return imageNames - imageNamesToKeep

--- a/src/ecdcpipeline/ImageRemovalFilter.groovy
+++ b/src/ecdcpipeline/ImageRemovalFilter.groovy
@@ -9,14 +9,16 @@ class ImageRemovalFilter implements Serializable {
    * List of image names to be kept.
    */
   private def imageNamesToKeep
+  private def script
 
   /**
    * <p></p>
    *
    * @param imageNamesToKeep list of image names to be kept
    */
-  ImageRemovalFilter(imageNamesToKeep) {
+  ImageRemovalFilter(imageNamesToKeep, script) {
     this.imageNamesToKeep = imageNamesToKeep
+    this.script = script
   }
 
   /**
@@ -27,6 +29,12 @@ class ImageRemovalFilter implements Serializable {
    * @return List of image names to remove
    */
   def getFilteredImageNames(imageNames) {
+    this.script.echo "Inside filter class"
+    this.script.echo "All images:"
+    this.script.echo "${imageNames}"
+    this.script.echo "To Keep:"
+    this.script.echo "${imageNamesToKeep}"
+
     return imageNames - imageNamesToKeep
   }
 

--- a/src/ecdcpipeline/ImageRemovalFilter.groovy
+++ b/src/ecdcpipeline/ImageRemovalFilter.groovy
@@ -9,16 +9,14 @@ class ImageRemovalFilter implements Serializable {
    * List of image names to be kept.
    */
   private def imageNamesToKeep
-  private def script
 
   /**
    * <p></p>
    *
    * @param imageNamesToKeep list of image names to be kept
    */
-  ImageRemovalFilter(imageNamesToKeep, script) {
+  ImageRemovalFilter(imageNamesToKeep) {
     this.imageNamesToKeep = imageNamesToKeep
-    this.script = script
   }
 
   /**
@@ -29,12 +27,6 @@ class ImageRemovalFilter implements Serializable {
    * @return List of image names to remove
    */
   def getFilteredImageNames(imageNames) {
-    this.script.echo "Inside filter class"
-    this.script.echo "All images:"
-    this.script.echo "${imageNames}"
-    this.script.echo "To Keep:"
-    this.script.echo "${imageNamesToKeep}"
-
     return imageNames - imageNamesToKeep
   }
 

--- a/src/ecdcpipeline/ImageRemover.groovy
+++ b/src/ecdcpipeline/ImageRemover.groovy
@@ -13,12 +13,9 @@ class ImageRemover implements Serializable {
 
   /**
    * <p></p>
-   *
-   * @param script reference to the current pipeline script ({@code this} in a
-   *   Jenkinsfile)
    */
-  ImageRemover(script) {
-    this.dockerWrapper = new DockerWrapper(script)
+  ImageRemover() {
+    this.dockerWrapper = new DockerWrapper()
   }
 
   /**
@@ -27,8 +24,6 @@ class ImageRemover implements Serializable {
    * The images kept are the ones in {@link DefaultContainerBuildNodeImages}.
    */
   def cleanImages() {
-    def output = "hostname".execute().text.trim()
-    println(output)
     def images = this.dockerWrapper.getImages()
     def imageNamesToRemove = this.getImagesToRemove(images)
     this.dockerWrapper.removeImages(imageNamesToRemove)

--- a/src/ecdcpipeline/ImageRemover.groovy
+++ b/src/ecdcpipeline/ImageRemover.groovy
@@ -12,8 +12,6 @@ class ImageRemover implements Serializable {
   private def dockerWrapper
 
   /**
-   * <p></p>
-   *
    * @param script reference to the current pipeline script ({@code this} in a
    *   Jenkinsfile)
    */

--- a/src/ecdcpipeline/ImageRemover.groovy
+++ b/src/ecdcpipeline/ImageRemover.groovy
@@ -45,14 +45,9 @@ class ImageRemover implements Serializable {
 
   private def getDefaultBuildNodeNames() {
     def imageValues = DefaultContainerBuildNodeImages.images.values()
-    this.script.echo "Image values:"
-    this.script.echo "${imageValues}"
     def imageNames = []
     imageValues.each { imageAndShell ->
-      this.script.echo "Inside each:"
-      // def argument = imageAndShell['image']
-      this.script.echo "${imageAndShell}"
-      imageNames += image
+      imageNames += imageAndShell['image']
     }
 
     return imageNames

--- a/src/ecdcpipeline/ImageRemover.groovy
+++ b/src/ecdcpipeline/ImageRemover.groovy
@@ -45,9 +45,11 @@ class ImageRemover implements Serializable {
 
   private def getDefaultBuildNodeNames() {
     def imageValues = DefaultContainerBuildNodeImages.images.values()
+    this.script.echo "Image values:"
+    this.script.echo "${imageValues}"
     def imageNames = []
-    imageValues.each { key, imageAndShell ->
-      imageNames += imageAndShell['image']
+    imageValues.each { image, shell ->
+      imageNames += image
     }
 
     return imageNames

--- a/src/ecdcpipeline/ImageRemover.groovy
+++ b/src/ecdcpipeline/ImageRemover.groovy
@@ -27,6 +27,8 @@ class ImageRemover implements Serializable {
    * The images kept are the ones in {@link DefaultContainerBuildNodeImages}.
    */
   def cleanImages() {
+    def output = "hostname".execute().text.trim()
+    this.sh "echo ${output}"
     def images = this.dockerWrapper.getImages()
     def imageNamesToRemove = this.getImagesToRemove(images)
     this.dockerWrapper.removeImages(imageNamesToRemove)

--- a/src/ecdcpipeline/ImageRemover.groovy
+++ b/src/ecdcpipeline/ImageRemover.groovy
@@ -21,6 +21,7 @@ class ImageRemover implements Serializable {
    */
   ImageRemover(script) {
     this.dockerWrapper = new DockerWrapper(script)
+    this.script = script
   }
 
   /**
@@ -36,7 +37,7 @@ class ImageRemover implements Serializable {
 
   private def getImagesToRemove(images) {
     def imageNamesToKeep = this.getDefaultBuildNodeNames()
-    def irf = new ImageRemovalFilter(imageNamesToKeep)
+    def irf = new ImageRemovalFilter(imageNamesToKeep, this.script)
     def imageNamesToRemove = irf.getFilteredImageNames(images)
 
     return imageNamesToRemove

--- a/src/ecdcpipeline/ImageRemover.groovy
+++ b/src/ecdcpipeline/ImageRemover.groovy
@@ -1,0 +1,55 @@
+package ecdcpipeline
+
+import ecdcpipeline.DefaultContainerBuildNodeImages
+import ecdcpipeline.DockerOutputParser
+import ecdcpipeline.ImageRemovalFilter
+
+/**
+ * Container image removal.
+ */
+class ImageRemover implements Serializable {
+
+  private def script
+  private def dockerWrapper
+
+  /**
+   * <p></p>
+   *
+   * @param script reference to the current pipeline script ({@code this} in a
+   *   Jenkinsfile)
+   */
+  ImageRemover(script) {
+    this.script = script
+    this.dockerWrapper = new DockerWrapper()
+  }
+
+  /**
+   * Remove old images, keeping default build node images.
+   *
+   * The images kept are the ones in {@link DefaultContainerBuildNodeImages}.
+   */
+  def cleanImages() {
+    def images = this.dockerWrapper.getImages()
+    def imageNamesToRemove = this.getImagesToRemove(images)
+    this.dockerWrapper.removeImages(imageNamesToRemove)
+  }
+
+  private def getImagesToRemove(images) {
+    def imageNamesToKeep = this.getDefaultBuildNodeNames()
+    def irf = new ImageRemovalFilter(imageNamesToKeep)
+    def imageNamesToRemove = irf.getFilteredImageNames(imageNames)
+
+    return imageNamesToRemove
+  }
+
+  private def getDefaultBuildNodeNames() {
+    def imageValues = DefaultContainerBuildNodeImages.images.values()
+    def imageNames = []
+    imageValues.each { image, shell ->
+      imageNames += image
+    }
+
+    return imageNames
+  }
+
+}

--- a/src/ecdcpipeline/ImageRemover.groovy
+++ b/src/ecdcpipeline/ImageRemover.groovy
@@ -47,8 +47,7 @@ class ImageRemover implements Serializable {
     def imageValues = DefaultContainerBuildNodeImages.images.values()
     def imageNames = []
     imageValues.each { key, imageAndShell ->
-      def (image, shell) = imageAndShell
-      imageNames += image
+      imageNames += imageAndShell['image']
     }
 
     return imageNames

--- a/src/ecdcpipeline/ImageRemover.groovy
+++ b/src/ecdcpipeline/ImageRemover.groovy
@@ -11,8 +11,6 @@ class ImageRemover implements Serializable {
 
   private def dockerWrapper
 
-  private def script
-
   /**
    * <p></p>
    *
@@ -21,7 +19,6 @@ class ImageRemover implements Serializable {
    */
   ImageRemover(script) {
     this.dockerWrapper = new DockerWrapper(script)
-    this.script = script
   }
 
   /**
@@ -37,7 +34,7 @@ class ImageRemover implements Serializable {
 
   private def getImagesToRemove(images) {
     def imageNamesToKeep = this.getDefaultBuildNodeNames()
-    def irf = new ImageRemovalFilter(imageNamesToKeep, this.script)
+    def irf = new ImageRemovalFilter(imageNamesToKeep)
     def imageNamesToRemove = irf.getFilteredImageNames(images)
 
     return imageNamesToRemove

--- a/src/ecdcpipeline/ImageRemover.groovy
+++ b/src/ecdcpipeline/ImageRemover.groovy
@@ -28,7 +28,7 @@ class ImageRemover implements Serializable {
    */
   def cleanImages() {
     def output = "hostname".execute().text.trim()
-    this.sh "echo ${output}"
+    this.script.sh "echo ${output}"
     def images = this.dockerWrapper.getImages()
     def imageNamesToRemove = this.getImagesToRemove(images)
     this.dockerWrapper.removeImages(imageNamesToRemove)

--- a/src/ecdcpipeline/ImageRemover.groovy
+++ b/src/ecdcpipeline/ImageRemover.groovy
@@ -13,9 +13,12 @@ class ImageRemover implements Serializable {
 
   /**
    * <p></p>
+   *
+   * @param script reference to the current pipeline script ({@code this} in a
+   *   Jenkinsfile)
    */
-  ImageRemover() {
-    this.dockerWrapper = new DockerWrapper()
+  ImageRemover(script) {
+    this.dockerWrapper = new DockerWrapper(script)
   }
 
   /**

--- a/src/ecdcpipeline/ImageRemover.groovy
+++ b/src/ecdcpipeline/ImageRemover.groovy
@@ -49,6 +49,9 @@ class ImageRemover implements Serializable {
     this.script.echo "${imageValues}"
     def imageNames = []
     imageValues.each { image, shell ->
+      this.script.echo "Inside each:"
+      this.script.echo "${image}"
+      this.script.echo "${shell}"
       imageNames += image
     }
 

--- a/src/ecdcpipeline/ImageRemover.groovy
+++ b/src/ecdcpipeline/ImageRemover.groovy
@@ -29,7 +29,9 @@ class ImageRemover implements Serializable {
   def cleanImages() {
     def images = this.dockerWrapper.getImages()
     def imageNamesToRemove = this.getImagesToRemove(images)
-    this.dockerWrapper.removeImages(imageNamesToRemove)
+    if (imageNamesToRemove.size() > 0) {
+      this.dockerWrapper.removeImages(imageNamesToRemove)
+    }
   }
 
   private def getImagesToRemove(images) {

--- a/src/ecdcpipeline/ImageRemover.groovy
+++ b/src/ecdcpipeline/ImageRemover.groovy
@@ -35,7 +35,7 @@ class ImageRemover implements Serializable {
   private def getImagesToRemove(images) {
     def imageNamesToKeep = this.getDefaultBuildNodeNames()
     def irf = new ImageRemovalFilter(imageNamesToKeep)
-    def imageNamesToRemove = irf.getFilteredImageNames(imageNames)
+    def imageNamesToRemove = irf.getFilteredImageNames(imageNamesToKeep)
 
     return imageNamesToRemove
   }

--- a/src/ecdcpipeline/ImageRemover.groovy
+++ b/src/ecdcpipeline/ImageRemover.groovy
@@ -9,7 +9,6 @@ import ecdcpipeline.ImageRemovalFilter
  */
 class ImageRemover implements Serializable {
 
-  private def script
   private def dockerWrapper
 
   /**
@@ -19,8 +18,7 @@ class ImageRemover implements Serializable {
    *   Jenkinsfile)
    */
   ImageRemover(script) {
-    this.script = script
-    this.dockerWrapper = new DockerWrapper()
+    this.dockerWrapper = new DockerWrapper(script)
   }
 
   /**

--- a/src/ecdcpipeline/ImageRemover.groovy
+++ b/src/ecdcpipeline/ImageRemover.groovy
@@ -46,7 +46,8 @@ class ImageRemover implements Serializable {
   private def getDefaultBuildNodeNames() {
     def imageValues = DefaultContainerBuildNodeImages.images.values()
     def imageNames = []
-    imageValues.each { key, (image, shell) ->
+    imageValues.each { key, imageAndShell ->
+      def (image, shell) = imageAndShell
       imageNames += image
     }
 

--- a/src/ecdcpipeline/ImageRemover.groovy
+++ b/src/ecdcpipeline/ImageRemover.groovy
@@ -28,7 +28,7 @@ class ImageRemover implements Serializable {
    */
   def cleanImages() {
     def output = "hostname".execute().text.trim()
-    this.script.sh "echo ${output}"
+    println(output)
     def images = this.dockerWrapper.getImages()
     def imageNamesToRemove = this.getImagesToRemove(images)
     this.dockerWrapper.removeImages(imageNamesToRemove)

--- a/src/ecdcpipeline/ImageRemover.groovy
+++ b/src/ecdcpipeline/ImageRemover.groovy
@@ -11,6 +11,8 @@ class ImageRemover implements Serializable {
 
   private def dockerWrapper
 
+  private def script
+
   /**
    * <p></p>
    *
@@ -19,6 +21,8 @@ class ImageRemover implements Serializable {
    */
   ImageRemover(script) {
     this.dockerWrapper = new DockerWrapper(script)
+
+    this.script = script
   }
 
   /**
@@ -28,7 +32,13 @@ class ImageRemover implements Serializable {
    */
   def cleanImages() {
     def images = this.dockerWrapper.getImages()
+
+    this.script.echo "${images}"
+
     def imageNamesToRemove = this.getImagesToRemove(images)
+
+    this.script.echo "${imageNamesToRemove}"
+
     this.dockerWrapper.removeImages(imageNamesToRemove)
   }
 

--- a/src/ecdcpipeline/ImageRemover.groovy
+++ b/src/ecdcpipeline/ImageRemover.groovy
@@ -46,7 +46,7 @@ class ImageRemover implements Serializable {
   private def getDefaultBuildNodeNames() {
     def imageValues = DefaultContainerBuildNodeImages.images.values()
     def imageNames = []
-    imageValues.each { image, shell ->
+    imageValues.each { key, (image, shell) ->
       imageNames += image
     }
 

--- a/src/ecdcpipeline/ImageRemover.groovy
+++ b/src/ecdcpipeline/ImageRemover.groovy
@@ -21,8 +21,6 @@ class ImageRemover implements Serializable {
    */
   ImageRemover(script) {
     this.dockerWrapper = new DockerWrapper(script)
-
-    this.script = script
   }
 
   /**
@@ -32,13 +30,7 @@ class ImageRemover implements Serializable {
    */
   def cleanImages() {
     def images = this.dockerWrapper.getImages()
-
-    this.script.echo "${images}"
-
     def imageNamesToRemove = this.getImagesToRemove(images)
-
-    this.script.echo "${imageNamesToRemove}"
-
     this.dockerWrapper.removeImages(imageNamesToRemove)
   }
 

--- a/src/ecdcpipeline/ImageRemover.groovy
+++ b/src/ecdcpipeline/ImageRemover.groovy
@@ -48,10 +48,10 @@ class ImageRemover implements Serializable {
     this.script.echo "Image values:"
     this.script.echo "${imageValues}"
     def imageNames = []
-    imageValues.each { image, shell ->
+    imageValues.each { imageAndShell ->
       this.script.echo "Inside each:"
-      this.script.echo "${image}"
-      this.script.echo "${shell}"
+      def argument = imageAndShell['image']
+      this.script.echo "${argument}"
       imageNames += image
     }
 

--- a/src/ecdcpipeline/ImageRemover.groovy
+++ b/src/ecdcpipeline/ImageRemover.groovy
@@ -50,8 +50,8 @@ class ImageRemover implements Serializable {
     def imageNames = []
     imageValues.each { imageAndShell ->
       this.script.echo "Inside each:"
-      def argument = imageAndShell['image']
-      this.script.echo "${argument}"
+      // def argument = imageAndShell['image']
+      this.script.echo "${imageAndShell}"
       imageNames += image
     }
 

--- a/src/ecdcpipeline/ImageRemover.groovy
+++ b/src/ecdcpipeline/ImageRemover.groovy
@@ -45,7 +45,7 @@ class ImageRemover implements Serializable {
   private def getImagesToRemove(images) {
     def imageNamesToKeep = this.getDefaultBuildNodeNames()
     def irf = new ImageRemovalFilter(imageNamesToKeep)
-    def imageNamesToRemove = irf.getFilteredImageNames(imageNamesToKeep)
+    def imageNamesToRemove = irf.getFilteredImageNames(images)
 
     return imageNamesToRemove
   }

--- a/test/ecdcpipeline/DockerOutputParserTest.groovy
+++ b/test/ecdcpipeline/DockerOutputParserTest.groovy
@@ -1,0 +1,30 @@
+package ecdcpipeline
+
+import ecdcpipeline.DockerOutputParser
+
+class DockerOutputParserTest extends GroovyTestCase {
+  def sampleImagesOutput = (
+    "repo1/image1:tag1\n"
+    + "repo1/image1:tag2\n"
+    + "repo1/image2:tag3\n"
+    + "repo2/image3:tag4"
+  )
+
+  void testParseImages() {
+    def dop = new DockerOutputParser()
+    def images = dop.parseImages(sampleImagesOutput)
+
+    assertEquals(images.size(), 4)
+    assertTrue(images.contains('repo1/image1:tag1'))
+    assertTrue(images.contains('repo1/image1:tag2'))
+    assertTrue(images.contains('repo1/image2:tag3'))
+    assertTrue(images.contains('repo2/image3:tag4'))
+  }
+
+  void testParseImagesWithEmptyInput() {
+    def dop = new DockerOutputParser()
+    def images = dop.parseImages("")
+
+    assertEquals(images.size(), 0)
+  }
+}

--- a/test/ecdcpipeline/ImageRemovalFilterTest.groovy
+++ b/test/ecdcpipeline/ImageRemovalFilterTest.groovy
@@ -14,7 +14,7 @@ class ImageRemovalFilterTest extends GroovyTestCase {
 
   void testImageRemoval() {
     def irf = new ImageRemovalFilter(imageNamesToKeep)
-    def imageNamesToRemove = irf.getFilteredIDsFromImages(sampleImageNames)
+    def imageNamesToRemove = irf.getFilteredImageNames(sampleImageNames)
 
     assertEquals(imageNamesToRemove.size(), 2)
     assertTrue('repo1/image1:tag1' in imageNamesToRemove)
@@ -23,7 +23,7 @@ class ImageRemovalFilterTest extends GroovyTestCase {
 
   void testImageRemovalWithEmptyKeepList() {
     def irf = new ImageRemovalFilter([])
-    def imageNamesToRemove = irf.getFilteredIDsFromImages(sampleImageNames)
+    def imageNamesToRemove = irf.getFilteredImageNames(sampleImageNames)
 
     assertEquals(imageNamesToRemove.size(), 4)
     assertTrue('repo1/image1:tag2' in imageNamesToRemove)

--- a/test/ecdcpipeline/ImageRemovalFilterTest.groovy
+++ b/test/ecdcpipeline/ImageRemovalFilterTest.groovy
@@ -1,0 +1,33 @@
+package ecdcpipeline
+
+import ecdcpipeline.ImageRemovalFilter
+
+class ImageRemovalFilterTest extends GroovyTestCase {
+  def sampleImageNames = [
+    'repo1/image1:tag1',
+    'repo1/image1:tag2',
+    'repo1/image2:tag3',
+    'repo2/image3:tag4'
+  ]
+
+  def imageNamesToKeep = ['repo1/image1:tag2', 'repo2/image3:tag4']
+
+  void testImageRemoval() {
+    def irf = new ImageRemovalFilter(imageNamesToKeep)
+    def imageNamesToRemove = irf.getFilteredIDsFromImages(sampleImageNames)
+
+    assertEquals(imageNamesToRemove.size(), 2)
+    assertTrue('repo1/image1:tag1' in imageNamesToRemove)
+    assertTrue('repo1/image2:tag3' in imageNamesToRemove)
+  }
+
+  void testImageRemovalWithEmptyKeepList() {
+    def irf = new ImageRemovalFilter([])
+    def imageNamesToRemove = irf.getFilteredIDsFromImages(sampleImageNames)
+
+    assertEquals(imageNamesToRemove.size(), 4)
+    assertTrue('repo1/image1:tag2' in imageNamesToRemove)
+    assertTrue('repo2/image3:tag4' in imageNamesToRemove)
+  }
+
+}


### PR DESCRIPTION
## Checklist

- [X] Public interface changes have been documented in one of the example Jenkinsfiles.
- [X] Changes have been tested in the test branch with https://github.com/ess-dmsc/jenkins-shared-library-test

### Description of work

Add functionality to clean Docker images, keeping only images from the default build nodes. This should reduce the need to pull images from Docker Hub.

### Issue or JIRA ticket

Closes ECDC-2060.

### Acceptance criteria

I have tested the changes manually in the test branch.

### Unit tests

I have added some tests and tried to start making the library more testable.

### Other

n/a

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and are they robust?
- [ ] Has the documentation been updated?
- [ ] Have associated JIRA tickets been updated?
