### PR TITLE
ECDC-2295 branch names with slashes

### DIFF
--- a/src/ecdcpipeline/PipelineBuilder.groovy
+++ b/src/ecdcpipeline/PipelineBuilder.groovy
@@ -65,20 +65,21 @@ class PipelineBuilder implements Serializable {
     this.containerBuildNodes = containerBuildNodes
     this.hostMounts = hostMounts
 
-    def job_name_elements = "${script.env.JOB_NAME}".tokenize('/')
+    def job_name = script.env.JOB_NAME.replace("%2F", "_")
+    def job_name_elements = job_name.tokenize('/')
     if (job_name_elements.size() != 3) {
       def msg = "'${script.env.JOB_NAME}' is not a valid job name " \
         + "(expected org/project/branch)"
       throw new IllegalArgumentException(msg)
     }
     this.project = job_name_elements[1]
-    this.branch = job_name_elements[2].replace("%2F", "_")
+    this.branch = job_name_elements[2]
 
     this.failure_messages = Collections.synchronizedList([])
     this.buildNumber = script.env.BUILD_NUMBER
     this.baseContainerName = "${project}-${branch}-${buildNumber}"
 
-    this.failureNotifier = new FailureNotifier(script.env.JOB_NAME)
+    this.failureNotifier = new FailureNotifier(job_name)
   }
 
   /**

--- a/src/ecdcpipeline/PipelineBuilder.groovy
+++ b/src/ecdcpipeline/PipelineBuilder.groovy
@@ -65,6 +65,7 @@ class PipelineBuilder implements Serializable {
     this.containerBuildNodes = containerBuildNodes
     this.hostMounts = hostMounts
 
+    // Replace percent-encoded slashes
     def job_name = script.env.JOB_NAME.replace("%2F", "_")
     def job_name_elements = job_name.tokenize('/')
     if (job_name_elements.size() != 3) {

--- a/src/ecdcpipeline/PipelineBuilder.groovy
+++ b/src/ecdcpipeline/PipelineBuilder.groovy
@@ -43,6 +43,9 @@ class PipelineBuilder implements Serializable {
   /**
    * <p></p>
    *
+   * @throws IllegalArgumentException if build node keys have wrong type or
+   *   JOB_NAME has wrong number of components.
+   *
    * @param script reference to the current pipeline script ({@code this} in a
    *   Jenkinsfile)
    * @param containerBuildNodes map with string keys and {@link
@@ -62,9 +65,15 @@ class PipelineBuilder implements Serializable {
     this.containerBuildNodes = containerBuildNodes
     this.hostMounts = hostMounts
 
-    def (org, project, branch) = "${script.env.JOB_NAME}".tokenize('/')
-    this.project = project
-    this.branch = branch
+    def job_name_elements = "${script.env.JOB_NAME}".tokenize('/')
+    if (job_name_elements.size() != 3) {
+      def msg = "'${script.env.JOB_NAME}' is not a valid job name " \
+        + "(expected org/project/branch)"
+      throw new IllegalArgumentException(msg)
+    }
+    this.project = job_name_elements[1]
+    this.branch = job_name_elements[2].replace("%2F", "_")
+
     this.failure_messages = Collections.synchronizedList([])
     this.buildNumber = script.env.BUILD_NUMBER
     this.baseContainerName = "${project}-${branch}-${buildNumber}"

--- a/test/ecdcpipeline/PipelineBuilderTest.groovy
+++ b/test/ecdcpipeline/PipelineBuilderTest.groovy
@@ -23,11 +23,29 @@ class PipelineBuilderTest extends GroovyTestCase {
     }
   }
 
-  void testPipelineBuilderProperties() {
+  void testProperties() {
     def pipelineBuilder = new PipelineBuilder(script, containerBuildNodes)
     assertEquals(pipelineBuilder.project, 'test-project')
     assertEquals(pipelineBuilder.branch, 'master')
     assertEquals(pipelineBuilder.buildNumber, '42')
     assertEquals(pipelineBuilder.baseContainerName, 'test-project-master-42')
+  }
+
+  void testBadJobNameRaisesException() {
+    script.Env.JOB_NAME = "way/too/many/components"
+    shouldFail(IllegalArgumentException.class) {
+      def pipelineBuilder = new PipelineBuilder(script, containerBuildNodes)
+    }
+
+    script.Env.JOB_NAME = "few/components"
+    shouldFail(IllegalArgumentException.class) {
+      def pipelineBuilder = new PipelineBuilder(script, containerBuildNodes)
+    }
+  }
+
+  void testBranchNameWithSlashesIsChanged() {
+    script.Env.JOB_NAME = "org/project/job%2Fname%2Fwith%2Fslashes"
+    def pipelineBuilder = new PipelineBuilder(script, containerBuildNodes)
+    assertEquals(pipelineBuilder.branch, "job_name_with_slashes")
   }
 }


### PR DESCRIPTION
## Checklist

- [X] Public interface changes have been documented in one of the example Jenkinsfiles.
- [x] Changes have been tested in the test branch with https://github.com/ess-dmsc/jenkins-shared-library-test

### Description of work

Make `PipelineBuilder` replace percent-encoded slashes in job names, which can include branch names with slashes (as created by dependabot).

### Issue or JIRA ticket

Closes ECDC-2295.

### Acceptance criteria

Percent-encoded slashes (%2F) in branch names should be replaced with underscores.

### Unit tests

- Renamed properties unit test
- Added test for number of components in job name
- Added test for percent-encoded slash replacement in job name

### Other

n/a

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and are they robust?
- [ ] Has the documentation been updated?
- [ ] Have associated JIRA tickets been updated?
