### PR TITLE
ECDC-1498 method for build metadata archiving

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ groovy --classpath src:test test/ecdcpipeline/<file_name>.groovy
 
 where `<file_name>` must be substituted with a test file name (_*Test.groovy_).
 
+The _runtests.sh_ script is provided to run all unit tests in the _test/ecdcpipeline_ directory. Note that it always returns 0, independently of the test results.
+
 ### Generating documentation pages
 
 To create the documentation pages locally, run from the root of this repository

--- a/examples/build/Jenkinsfile
+++ b/examples/build/Jenkinsfile
@@ -108,9 +108,14 @@ node {
     }
 
     parallel builders
-    } catch (e) {
-      pipelineBuilder.handleFailureMessages()
-      throw e
+
+    pipelineBuilder.stage("Archive") {
+      // Archive build metadata.
+      pipelineBuilder.archiveBuildInfo()
+    }
+  } catch (e) {
+    pipelineBuilder.handleFailureMessages()
+    throw e
   }
 }
 

--- a/src/ecdcpipeline/PipelineBuilder.groovy
+++ b/src/ecdcpipeline/PipelineBuilder.groovy
@@ -151,6 +151,22 @@ class PipelineBuilder implements Serializable {
   }
 
   /**
+   * Create and archive BUILD_INFO file.
+   *
+   * If a file with this name exists in the current directory, build
+   * information will be appended to it.
+   */
+  def archiveBuildInfo() {
+    script.sh("""
+      touch BUILD_INFO
+      echo 'Repository: ${this.project}/${this.branch}' >> BUILD_INFO
+      echo 'Commit: ${script.scm_vars.GIT_COMMIT}' >> BUILD_INFO
+      echo 'Jenkins build: ${script.env.BUILD_NUMBER}' >> BUILD_INFO
+    """)
+    script.archiveArtifacts "BUILD_INFO"
+  }
+
+  /**
    * Get a Jenkins pipeline stage with automated failure messages.
    *
    * If an exception occurs inside the stage block, the messages are saved for


### PR DESCRIPTION
## Checklist

- [x] Public interface changes have been documented in one of the example Jenkinsfiles.
- [x] Changes have been tested in the test branch with https://github.com/ess-dmsc/jenkins-shared-library-test

### Description of work

Add method for archiving build metadata.

### Issue or JIRA ticket

Closes ECDC-1498.

### Acceptance criteria

The added method should replace the BUILD_INFO creation functionality currently implemented manually for projects using the shared library.

### Unit tests

n/a

### Other

n/a

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and are they robust?
- [ ] Has the documentation been updated?
- [ ] Have associated JIRA tickets been updated?
