### PR TITLE
ECDC-901: Automate build node builds

### DIFF
--- a/examples/docker/Jenkinsfile
+++ b/examples/docker/Jenkinsfile
@@ -1,0 +1,23 @@
+// This Jenkinsfile assumes you are familiar with the use of the library as
+// presented in the build/Jenkinsfile example file.
+@Library('ecdc-pipeline')
+import ecdcpipeline.ImageBuilder
+
+// Disable concurrent builds to avoid overwritting images in the registry.
+properties([
+  [$class: 'JiraProjectProperty'],
+  disableConcurrentBuilds(abortPrevious: true)
+])
+
+// imageVersion should be updated when changes are made to the Dockerfile. It
+// is assumed that the Jenkins node has already authenticated with the
+// container registry.
+imageVersion = '1.2.3'
+imageName = "dockerregistry.esss.dk/ecdc_group/build-node-images/custom-build-node:${imageVersion}"
+
+// ImageBuilder will append "-dev" to the version if the branch is not
+// "master", and "-pr" if the build is due to a pull request. These versions
+// of the image can be overwritten, but overwriting is not allowed when
+// building the "master" branch.
+imageBuilder = new ImageBuilder(this, imageName)
+imageBuilder.buildAndPush()

--- a/src/ecdcpipeline/ImageBuilder.groovy
+++ b/src/ecdcpipeline/ImageBuilder.groovy
@@ -54,21 +54,21 @@ class ImageBuilder {
         """
       }  // stage
 
-      stage("Push") {
-        if (env.BRANCH_NAME == 'master') {
+      script.stage("Push") {
+        if (script.env.BRANCH_NAME == 'master') {
           // Don't overwrite image if it exists.
           try {
-            // How to check if an image exists?
-            sh "docker manifest inspect ${image_name}"
-            error "Image ${image_name} already exists in registry, cannot push from master."
+            // Is there another way of checking if an image exists?
+            script.sh "docker manifest inspect ${this.imageName}"
+            script.error "Image ${this.imageName} already exists in registry, cannot push from master."
           } catch (e) {
-            echo "Image ${image_name} not found in registry and will be pushed."
+            script.echo "Image ${this.imageName} not found in registry and will be pushed."
           }
         } else {
-          echo "Not in master, image will be pushed."
+          script.echo "Not in master, image will be pushed."
         }
 
-        sh "docker push ${image_name}"
+        script.sh "docker push ${this.ImageName}"
       }  // stage
     }  // node
   }  // def

--- a/src/ecdcpipeline/ImageBuilder.groovy
+++ b/src/ecdcpipeline/ImageBuilder.groovy
@@ -1,0 +1,76 @@
+package ecdcpipeline
+
+/**
+ * Automated Docker build image builder and uploader.
+ */
+class ImageBuilder {
+
+  private def script
+  private String imageName
+
+  /**
+   * <p></p>
+   *
+   * @param script reference to the current pipeline script ({@code this} in a
+   *   Jenkinsfile)
+   * @param imageName Docker image name with version
+   */
+  ConanPackageBuilder(script, String imageName) {
+    this.script = script
+    this.imageName = imageName
+  }
+
+  /**
+   * Build Docker image and push to container registry.
+   *
+   * It is assumed that the Jenkins node has already authenticated with the
+   * container registry.
+   */
+  def buildAndPush() {
+    return node('docker') {
+      // Delete workspace when build is done.
+      cleanWs()
+
+      script.stage('Checkout') {
+        script.checkout script.scm
+      }
+      
+      script.stage('Build') {
+        // Add prefix for non-master builds.
+        if (script.env.CHANGE_ID) {
+          // Pull request.
+          this.imageName = "${this.imageName}-pr"
+        } else if (script.env.BRANCH_NAME != 'master') {
+          // Development branch.
+          this.imageName = "${this.imageName}-dev"
+        }
+
+        script.echo "Building image ${this.imageName}"
+        script.sh """
+          docker build \
+            --build-arg http_proxy=${script.env.http_proxy} \
+            --build-arg https_proxy=${script.env.https_proxy} \
+            -t ${this.imageName} .
+        """
+      }  // stage
+
+      stage("Push") {
+        if (env.BRANCH_NAME == 'master') {
+          // Don't overwrite image if it exists.
+          try {
+            // How to check if an image exists?
+            sh "docker manifest inspect ${image_name}"
+            error "Image ${image_name} already exists in registry, cannot push from master."
+          } catch (e) {
+            echo "Image ${image_name} not found in registry and will be pushed."
+          }
+        } else {
+          echo "Not in master, image will be pushed."
+        }
+
+        sh "docker push ${image_name}"
+      }  // stage
+    }  // node
+  }  // def
+
+}

--- a/src/ecdcpipeline/ImageBuilder.groovy
+++ b/src/ecdcpipeline/ImageBuilder.groovy
@@ -27,9 +27,9 @@ class ImageBuilder {
    * container registry.
    */
   def buildAndPush() {
-    return node('docker') {
+    return script.node('docker') {
       // Delete workspace when build is done.
-      cleanWs()
+      script.cleanWs()
 
       script.stage('Checkout') {
         script.checkout script.scm

--- a/src/ecdcpipeline/ImageBuilder.groovy
+++ b/src/ecdcpipeline/ImageBuilder.groovy
@@ -15,7 +15,7 @@ class ImageBuilder {
    *   Jenkinsfile)
    * @param imageName Docker image name with version
    */
-  ConanPackageBuilder(script, String imageName) {
+  ImageBuilder(script, String imageName) {
     this.script = script
     this.imageName = imageName
   }


### PR DESCRIPTION
## Checklist

- [X] Public interface changes have been documented in one of the example Jenkinsfiles.
- [X] Changes have been tested in the test branch with https://github.com/ess-dmsc/jenkins-shared-library-test

### Description of work

Automate build of Docker images for Jenkins build nodes.

### Issue or JIRA ticket

ECDC-901

### Acceptance criteria

- New ImageBuilder.buildAndTest() method should build and push Docker image to the internal container registry
- Images in development branch builds should have the prefix `-dev` added automatically
- Images in pull request builds should have the prefix `-pr` added automatically
- The master branch should not overwrite already existing images when pushing

### Unit tests

n/a

### Other

n/a

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and are they robust?
- [ ] Has the documentation been updated?
- [ ] Have associated JIRA tickets been updated?
