### PR TITLE
Use v7.1.0 for centos7-gcc11

### DIFF
--- a/src/ecdcpipeline/DefaultContainerBuildNodeImages.groovy
+++ b/src/ecdcpipeline/DefaultContainerBuildNodeImages.groovy
@@ -4,7 +4,7 @@ package ecdcpipeline
 class DefaultContainerBuildNodeImages {
   static images = [
     'centos7-gcc11': [
-      'image': 'dockerregistry.esss.dk/ecdc_group/build-node-images/centos7-build-node:7.0.0',
+      'image': 'dockerregistry.esss.dk/ecdc_group/build-node-images/centos7-build-node:7.1.0',
       'shell': '/usr/bin/scl enable devtoolset-11 rh-python38 -- /bin/bash -e -x'
     ],
     'centos7-gcc8': [


### PR DESCRIPTION
## Checklist

- [ ] Public interface changes have been documented in one of the example Jenkinsfiles.
- [ ] Changes have been tested in the test branch with https://github.com/ess-dmsc/jenkins-shared-library-test

### Description of work

Bump centos7-gcc11 to node image v7.1.0 (the version adds cyrus SASL development libraries)


---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and are they robust?
- [ ] Has the documentation been updated?
- [ ] Have associated JIRA tickets been updated?
