### PR TITLE
Bump build node versions and update examples

### DIFF
--- a/examples/build/Jenkinsfile
+++ b/examples/build/Jenkinsfile
@@ -16,9 +16,9 @@ import ecdcpipeline.DeploymentTrigger
 // this library is updated; use the custom image if you want to keep the version
 // fixed or if the image you require is not provided by the library.
 containerBuildNodes = [
-  'centos-debug': ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc8'),
-  'centos-release': ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc8'),
-  'ubuntu': new ContainerBuildNode('screamingudder/ubuntu18.04-build-node:4.0.1', 'bash -e')
+  'centos-debug': ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc11'),
+  'centos-release': ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc11'),
+  'ubuntu': new ContainerBuildNode('dockerregistry.esss.dk/ecdc_group/build-node-images/ubuntu22.04-build-node:4.0.0', 'bash -e')
 ]
 
 // Instantiate a PipelineBuilder object to generate the builders, mounting the

--- a/examples/conan/Jenkinsfile
+++ b/examples/conan/Jenkinsfile
@@ -7,9 +7,9 @@ import ecdcpipeline.ConanPackageBuilder
 conanPackageChannel = 'stable'
 
 containerBuildNodes = [
-  'centos': ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc8'),
-  'debian': ContainerBuildNode.getDefaultContainerBuildNode('debian10'),
-  'ubuntu': ContainerBuildNode.getDefaultContainerBuildNode('ubuntu1804-gcc8')
+  'centos': ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc11'),
+  'debian': ContainerBuildNode.getDefaultContainerBuildNode('debian11'),
+  'ubuntu': ContainerBuildNode.getDefaultContainerBuildNode('ubuntu2204')
 ]
 
 // Instantiate a ConanPackageBuilder object to generate the package builder.

--- a/src/ecdcpipeline/DefaultContainerBuildNodeImages.groovy
+++ b/src/ecdcpipeline/DefaultContainerBuildNodeImages.groovy
@@ -4,23 +4,19 @@ package ecdcpipeline
 class DefaultContainerBuildNodeImages {
   static images = [
     'centos7-gcc11': [
-      'image': 'dockerregistry.esss.dk/ecdc_group/build-node-images/centos7-build-node:11.2.0',
+      'image': 'dockerregistry.esss.dk/ecdc_group/build-node-images/centos7-build-node:12.0.0',
       'shell': '/usr/bin/scl enable devtoolset-11 rh-python38 -- /bin/bash -e -x'
     ],
-    'centos7-gcc8': [
-      'image': 'dockerregistry.esss.dk/ecdc_group/build-node-images/centos7-build-node:6.4.0',
-      'shell': '/usr/bin/scl enable devtoolset-8 rh-python38 -- /bin/bash -e -x'
-    ],
     'almalinux8-gcc12': [
-      'image': 'dockerregistry.esss.dk/ecdc_group/build-node-images/almalinux8-build-node:0.2.0',
+      'image': 'dockerregistry.esss.dk/ecdc_group/build-node-images/almalinux8-build-node:1.0.0',
       'shell': '/usr/bin/scl enable gcc-toolset-12 -- /bin/bash -e -x'
     ],
     'debian11': [
-      'image': 'dockerregistry.esss.dk/ecdc_group/build-node-images/debian11-build-node:3.1.0',
+      'image': 'dockerregistry.esss.dk/ecdc_group/build-node-images/debian11-build-node:4.0.0',
       'shell': 'bash -e -x'
     ],
     'ubuntu2204': [
-      'image': 'dockerregistry.esss.dk/ecdc_group/build-node-images/ubuntu22.04-build-node:3.1.0',
+      'image': 'dockerregistry.esss.dk/ecdc_group/build-node-images/ubuntu22.04-build-node:4.0.0',
       'shell': 'bash -e -x'
     ]
   ]


### PR DESCRIPTION
## Checklist

- [X] Public interface changes have been documented in one of the example Jenkinsfiles.
- [X] Changes have been tested in the test branch with https://github.com/ess-dmsc/jenkins-shared-library-test

### Description of work

Update build node versions for new Conan configuration, removing the bincrafters repository. Also removed old CentOS build node with older version of GCC.

### Issue or JIRA ticket

ECDC-2897

### Acceptance criteria

n/a

### Unit tests

n/a

### Other

n/a

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and are they robust?
- [ ] Has the documentation been updated?
- [ ] Have associated JIRA tickets been updated?
