### PR TITLE
Update default debian to 5.0.0

### DIFF
--- a/src/ecdcpipeline/DefaultContainerBuildNodeImages.groovy
+++ b/src/ecdcpipeline/DefaultContainerBuildNodeImages.groovy
@@ -12,7 +12,7 @@ class DefaultContainerBuildNodeImages {
       'shell': '/usr/bin/scl enable gcc-toolset-12 -- /bin/bash -e -x'
     ],
     'debian11': [
-      'image': 'dockerregistry.esss.dk/ecdc_group/build-node-images/debian11-build-node:4.0.0',
+      'image': 'dockerregistry.esss.dk/ecdc_group/build-node-images/debian11-build-node:5.0.0',
       'shell': 'bash -e -x'
     ],
     'ubuntu2204': [


### PR DESCRIPTION
## Checklist

- [X] Public interface changes have been documented in one of the example Jenkinsfiles.
- [ ] Changes have been tested in the test branch with https://github.com/ess-dmsc/jenkins-shared-library-test

### Description of work

Update default Debian image.

### Issue or JIRA ticket

n/a

### Other

n/a
