### PR TITLE
ECDC-4485: Update QPlot to Qt6

### DIFF
--- a/src/ecdcpipeline/DefaultContainerBuildNodeImages.groovy
+++ b/src/ecdcpipeline/DefaultContainerBuildNodeImages.groovy
@@ -3,6 +3,10 @@ package ecdcpipeline
 
 class DefaultContainerBuildNodeImages {
   static images = [
+    'centos7-gcc11-qt6': [
+      'image': 'registry.esss.lu.se/ecdc/ess-dmsc/docker-centos7-build-node-qt6:12.3.0',
+      'shell': '/usr/bin/scl enable devtoolset-11 rh-python38 -- /bin/bash -e -x'
+    ],
     'centos7-gcc11': [
       'image': 'registry.esss.lu.se/ecdc/ess-dmsc/docker-centos7-build-node:12.3.0',
       'shell': '/usr/bin/scl enable devtoolset-11 rh-python38 -- /bin/bash -e -x'


### PR DESCRIPTION
## Checklist
- [x] Public interface changes have been documented in one of the example Jenkinsfiles.
- [x] Changes have been tested in the test branch with https://github.com/ess-dmsc/jenkins-shared-library-test

### Description of work
This PR adds an entry for a new Centos7-based docker image with Qt6 support to

```
src/ecdcpipeline/DefaultContainerBuildNodeImages.groovy
```
### Issue or JIRA ticket
- https://jira.ess.eu/browse/ECDC-4485
- https://jira.ess.eu/browse/ECDC-2861

### Other

*Give information on anything else that might be relevant to the reviewer. Such as added system tests, updated documentation etc.*
