### PR TITLE
[ECDC-4536] Add login to GitLab Docker registry

### DIFF
--- a/src/ecdcpipeline/PipelineBuilder.groovy
+++ b/src/ecdcpipeline/PipelineBuilder.groovy
@@ -213,6 +213,17 @@ class PipelineBuilder implements Serializable {
 
     def builder = {
       script.node('docker') {
+
+        script.withCredentials([
+          script.usernamePassword(
+            credentialsId: 'dmsc-gitlab-docker-registry-username-token', 
+            usernameVariable: 'REGISTRY_USER', 
+            passwordVariable: 'REGISTRY_PASS'
+          )
+        ]) {
+            script.sh('docker login -u $REGISTRY_USER -p $REGISTRY_PASS registry.esss.lu.se')
+        }
+
         try {
           def image = script.docker.image(containerBuildNode.image)
           image.run("\


### PR DESCRIPTION
### Description of work

Added login to our internal GitLab Docker Registry so the build node images can also be pulled from there.

### Issue or JIRA ticket

Closes [ECDC-4536](https://jira.ess.eu/browse/ECDC-4536)

