### PR TITLE
ECDC-4548: Qt6 support for the ubuntu2204 docker image

### DIFF
--- a/src/ecdcpipeline/DefaultContainerBuildNodeImages.groovy
+++ b/src/ecdcpipeline/DefaultContainerBuildNodeImages.groovy
@@ -7,18 +7,27 @@ class DefaultContainerBuildNodeImages {
       'image': 'registry.esss.lu.se/ecdc/ess-dmsc/build-nodes/centos7-qt6:1.0',
       'shell': '/usr/bin/scl enable devtoolset-11 rh-python38 -- /bin/bash -e -x'
     ],
+
     'centos7-gcc11': [
       'image': 'registry.esss.lu.se/ecdc/ess-dmsc/docker-centos7-build-node:12.3.0',
       'shell': '/usr/bin/scl enable devtoolset-11 rh-python38 -- /bin/bash -e -x'
     ],
+
     'almalinux8-gcc12': [
       'image': 'registry.esss.lu.se/ecdc/ess-dmsc/docker-almalinux8-build-node:1.1.0',
       'shell': '/usr/bin/scl enable gcc-toolset-12 -- /bin/bash -e -x'
     ],
+
     'debian11': [
       'image': 'registry.esss.lu.se/ecdc/ess-dmsc/docker-debian11-build-node:5.2.0',
       'shell': 'bash -e -x'
     ],
+
+    'ubuntu2204-qt6': [
+      'image': 'registry.esss.lu.se/ecdc/ess-dmsc/build-nodes/ubuntu2204-qt6:1.0',
+      'shell': 'bash -e -x'
+    ]
+
     'ubuntu2204': [
       'image': 'registry.esss.lu.se/ecdc/ess-dmsc/docker-ubuntu2204-build-node:5.0.0',
       'shell': 'bash -e -x'


### PR DESCRIPTION
## Checklist

- [x] Public interface changes have been documented in one of the example Jenkinsfiles.
- [x] Changes have been tested in the test branch with https://github.com/ess-dmsc/jenkins-shared-library-test

### Description of work
Qt6 support for the ubuntu2204 docker image is required by the [Conan QPlot package](https://gitlab.esss.lu.se/ecdc/ess-dmsc/conan-qplot)

### Issue or JIRA ticket
https://jira.ess.eu/browse/ECDC-4548

### Other
None