### PR TITLE
ECDC-4548: Qt6 support for the ubuntu2204 docker image - fix-up

### DIFF
--- a/src/ecdcpipeline/DefaultContainerBuildNodeImages.groovy
+++ b/src/ecdcpipeline/DefaultContainerBuildNodeImages.groovy
@@ -26,7 +26,7 @@ class DefaultContainerBuildNodeImages {
     'ubuntu2204-qt6': [
       'image': 'registry.esss.lu.se/ecdc/ess-dmsc/build-nodes/ubuntu2204-qt6:1.0',
       'shell': 'bash -e -x'
-    ]
+    ],
 
     'ubuntu2204': [
       'image': 'registry.esss.lu.se/ecdc/ess-dmsc/docker-ubuntu2204-build-node:5.0.0',


### PR DESCRIPTION
## Checklist

- [x] Public interface changes have been documented in one of the example Jenkinsfiles.
- [x] Changes have been tested in the test branch with https://github.com/ess-dmsc/jenkins-shared-library-test

### Description of work
Qt6 support for the ubuntu2204 docker image is required by the [Conan QPlot package](https://gitlab.esss.lu.se/ecdc/ess-dmsc/conan-qplot)

Adding missing comma

### Issue or JIRA ticket
https://jira.ess.eu/browse/ECDC-4548

### Other
None