### PR TITLE
ECDC-4548: Qt6 support for the ubuntu2204 docker image

### DIFF
--- a/src/ecdcpipeline/DefaultContainerBuildNodeImages.groovy
+++ b/src/ecdcpipeline/DefaultContainerBuildNodeImages.groovy
@@ -24,7 +24,7 @@ class DefaultContainerBuildNodeImages {
     ],
 
     'ubuntu2204-qt6': [
-      'image': 'registry.esss.lu.se/ecdc/ess-dmsc/build-nodes/ubuntu2204-qt6:1.0',
+      'image': 'registry.esss.lu.se/ecdc/ess-dmsc/build-nodes/ubuntu2204-qt6:1.1',
       'shell': 'bash -e -x'
     ],
 


### PR DESCRIPTION
## Checklist

- [x] Public interface changes have been documented in one of the example Jenkinsfiles.
- [x] Changes have been tested in the test branch with https://github.com/ess-dmsc/jenkins-shared-library-test

### Description of work

Updating docker image version number


### Issue or JIRA ticket
https://jira.ess.eu/browse/ECDC-4548

### Other

*Give information on anything else that might be relevant to the reviewer. Such as added system tests, updated documentation etc.*
